### PR TITLE
Added README and basic testing; fixed circular dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,5 @@ lint: pyproject.toml setup.cfg
 clean:
 	find . -type f -name "*~" -exec rm -f {} +
 
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# utils
+
+This package provides utilities for use across the Forecast Research Institute's codebase.
+
+# Structure
+
+- `archiving/` - Utility functions for tar.gz compression & extraction.
+- `gcp/` - Utilities for interacting with Google Cloud Storage.
+
+# Development
+
+## Install
+
+First, install dependencies. We recommend using a virtual environment:
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -r requirements.txt
+```
+
+## Test
+
+```
+make test
+```
+
+## Contributing
+
+Be sure to lint your contribution before creating a pull request:
+
+```
+make lint
+```

--- a/gcp/storage.py
+++ b/gcp/storage.py
@@ -5,19 +5,14 @@ import pathlib
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from . import (
-    storage_download_file,
-    storage_list_files,
-    storage_list_files_with_prefix,
-    storage_upload_file,
-)
-
 
 def list_with_prefix(
     bucket_name: str,
     prefix: str,
 ):
     """List files in the folder specified by `prefix`."""
+    from . import storage_list_files_with_prefix
+
     return storage_list_files_with_prefix.list_blobs_with_prefix(
         bucket_name=bucket_name,
         prefix=prefix,
@@ -47,6 +42,8 @@ def list(
                 retval.append(rel_path)
         return retval
 
+    from . import storage_list_files
+
     return storage_list_files.list_blobs(
         bucket_name=bucket_name,
     )
@@ -60,6 +57,8 @@ def upload(
     filename: str = None,
 ):
     """Facilitate uploading file to cloud storage."""
+    from . import storage_upload_file
+
     if not filename:
         filename = os.path.basename(local_filename)
     destination_filename = f"{destination_folder}/{filename}" if destination_folder else filename
@@ -77,6 +76,8 @@ def download(
     local_filename: str = None,
 ) -> str:
     """Facilitate downloading file from cloud storage."""
+    from . import storage_download_file
+
     if not local_filename:
         directory, basename = os.path.split(filename)
         local_directory = f"/tmp/{directory}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ line-length = 100
 force-exclude = '''
 (
     ^/venv/
+    | ^/\.venv/
     | ^/gcp/storage_download_file.py
     | ^/gcp/storage_upload_file.py
     | ^/gcp/storage_list_files_with_prefix.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [isort]
 skip =
     venv,
+    .venv,
     gcp/storage_download_file.py,
     gcp/storage_upload_file.py,
     gcp/storage_list_files_with_prefix.py
@@ -10,6 +11,7 @@ profile = black
 # some rules from https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 exclude =
     venv,
+    .venv,
     gcp/storage_download_file.py,
     gcp/storage_upload_file.py,
     gcp/storage_list_files_with_prefix.py
@@ -21,4 +23,4 @@ per-file-ignores =
 
 [pydocstyle]
 match = (?!storage_).*\.py
-match-dir = ^(?!(venv)).*$
+match-dir = ^(?!(venv|\.venv)).*$

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests package for utils."""

--- a/tests/test_archiving.py
+++ b/tests/test_archiving.py
@@ -1,0 +1,121 @@
+"""Tests for archiving utilities."""
+
+import os
+import tarfile
+import tempfile
+
+from utils.archiving.tar_gz import compress, extract
+
+
+def test_compress_multiple_files():
+    """Test compressing multiple files into a single tar.gz archive."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create multiple test files
+        test_files = []
+        for i in range(3):
+            test_file = os.path.join(tmpdir, f"test_{i}.txt")
+            with open(test_file, "w") as f:
+                f.write(f"Content {i}")
+            test_files.append(test_file)
+
+        # Compress them
+        archive_path = os.path.join(tmpdir, "test.tar.gz")
+        result = compress(test_files, archive_path)
+
+        # Verify the archive was created
+        assert result == archive_path
+        assert os.path.exists(archive_path)
+
+        # Verify the archive contains all files
+        with tarfile.open(archive_path, "r:gz") as archive:
+            members = archive.getnames()
+            assert len(members) == 3
+            assert "test_0.txt" in members
+            assert "test_1.txt" in members
+            assert "test_2.txt" in members
+
+
+def test_extract_archive():
+    """Test extracting a tar.gz archive."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test files
+        test_files = []
+        for i in range(3):
+            test_file = os.path.join(tmpdir, f"test_{i}.txt")
+            with open(test_file, "w") as f:
+                f.write(f"Content {i}")
+            test_files.append(test_file)
+
+        # Create an archive
+        archive_path = os.path.join(tmpdir, "test.tar.gz")
+        compress(test_files, archive_path)
+
+        # Extract the archive
+        extract_dir = os.path.join(tmpdir, "extracted")
+        result = extract(archive_path, extract_dir)
+
+        # Verify the extraction directory was created
+        assert result == extract_dir
+        assert os.path.isdir(extract_dir)
+
+        # Verify all files were extracted with correct content
+        for i in range(3):
+            extracted_file = os.path.join(extract_dir, f"test_{i}.txt")
+            assert os.path.exists(extracted_file)
+            with open(extracted_file, "r") as f:
+                assert f.read() == f"Content {i}"
+
+
+def test_extract_with_rm_dir_before_extract():
+    """Test extracting with rm_dir_before_extract parameter."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test files
+        test_files = []
+        for i in range(2):
+            test_file = os.path.join(tmpdir, f"test_{i}.txt")
+            with open(test_file, "w") as f:
+                f.write(f"Content {i}")
+            test_files.append(test_file)
+
+        # Create an archive
+        archive_path = os.path.join(tmpdir, "test.tar.gz")
+        compress(test_files, archive_path)
+
+        # Create a directory with some files that should be removed
+        extract_dir = os.path.join(tmpdir, "extracted")
+        os.makedirs(extract_dir, exist_ok=True)
+        old_file = os.path.join(extract_dir, "old_file.txt")
+        with open(old_file, "w") as f:
+            f.write("This should be removed")
+
+        # Extract with rm_dir_before_extract
+        _ = extract(archive_path, extract_dir, rm_dir_before_extract=extract_dir)
+
+        # Verify old file is gone and new files are extracted
+        assert not os.path.exists(old_file)
+        assert os.path.exists(os.path.join(extract_dir, "test_0.txt"))
+        assert os.path.exists(os.path.join(extract_dir, "test_1.txt"))
+
+
+def test_extract_with_rm_archive_on_extract():
+    """Test extracting with rm_archive_on_extract parameter."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create test files
+        test_files = []
+        test_file = os.path.join(tmpdir, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("Content")
+        test_files.append(test_file)
+
+        # Create an archive
+        archive_path = os.path.join(tmpdir, "test.tar.gz")
+        compress(test_files, archive_path)
+
+        # Extract with rm_archive_on_extract
+        extract_dir = os.path.join(tmpdir, "extracted")
+        _ = extract(archive_path, extract_dir, rm_archive_on_extract=True)
+
+        # Verify archive was removed
+        assert not os.path.exists(archive_path)
+        # Verify files were extracted
+        assert os.path.exists(os.path.join(extract_dir, "test.txt"))


### PR DESCRIPTION
This PR adds a README and some basic testing infrastructure.

I began by testing the archiving methods, as those methods are the most straightforward to unit test.

The only diversion here was a circular import I noticed. This circular import was caused by:

- `gcp/__init__.py` imports storage at module level: `from . import storage`
- `gcp/storage.py` imported the storage_* modules at the top level (lines 8-13)
- Those modules import `google.cloud.storage` at module level

As a result, when Python imported gcp, it:

- Started importing `storage.py`
- Immediately executed the top-level imports in `storage.py`
- Tries to `import storage_download_file`, `storage_list_files`, etc.
- ...And those modules `import google.cloud.storage`

This created a cycle during module initialization. I fixed this circular import by lazily importing these dependencies in `storage.py`.