### PR TITLE
Decouple GCP and keys (plus clean-up).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,8 @@ test:
 test-integration:
 	pytest --integration
 
+test-integration-parallel:
+	pytest --integration -n auto
+
 coverage:
 	pytest --cov=utils --cov-report=term-missing --cov-report=html

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make test
 To run integration tests:
 
 ```
-make test-integration
+make test-integration-parallel
 ```
 
 ## Contributing

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,5 @@ __all__ = [
     "archiving",
     "gcp",
     "helpers",
-    "keys",
 ]
-from . import archiving, gcp, helpers, keys
+from . import archiving, gcp, helpers

--- a/gcp/__init__.py
+++ b/gcp/__init__.py
@@ -1,3 +1,9 @@
 """Google Cloud Platform related utilities."""
 
 from . import storage
+from .secret_manager import get_secret
+
+__all__ = [
+    "get_secret",
+    "storage",
+]

--- a/gcp/secret_manager.py
+++ b/gcp/secret_manager.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
 
-from google.api_core import exceptions as gcloud_exceptions
 from google.cloud import secretmanager
 
-from ..helpers.constants import GOOGLE_CLOUD_PROJECT_ENV_VAR
+from helpers.constants import GOOGLE_CLOUD_PROJECT_ENV_VAR
 
 
 def get_project_id() -> str:
@@ -39,11 +37,3 @@ def get_secret(secret_name: str, version_id: str = "latest") -> str:
     if not isinstance(payload_bytes, (bytes, bytearray)):
         raise TypeError("Secret payload data must be bytes.")
     return bytes(payload_bytes).decode("utf-8")
-
-
-def get_secret_that_may_not_exist(secret_name: str, version_id: str = "latest") -> Optional[str]:
-    """Return the secret payload if it exists, otherwise None."""
-    try:
-        return get_secret(secret_name, version_id)
-    except gcloud_exceptions.NotFound:
-        return None

--- a/keys/__init__.py
+++ b/keys/__init__.py
@@ -1,8 +1,0 @@
-"""Secret access helpers."""
-
-from .secrets import get_secret, get_secret_that_may_not_exist
-
-__all__ = [
-    "get_secret",
-    "get_secret_that_may_not_exist",
-]

--- a/llm/model_registry.py
+++ b/llm/model_registry.py
@@ -6,6 +6,16 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Final, Type
 
+from gcp.secret_manager import get_secret
+from helpers.constants import (
+    ANTHROPIC_API_KEY_SECRET_NAME,
+    GOOGLE_GEMINI_API_KEY_SECRET_NAME,
+    MISTRAL_API_KEY_SECRET_NAME,
+    OPENAI_API_KEY_SECRET_NAME,
+    TOGETHER_API_KEY_SECRET_NAME,
+    XAI_API_KEY_SECRET_NAME,
+)
+
 from .lab_registry import LABS, Lab
 from .providers.anthropic import AnthropicProvider
 from .providers.base import BaseLLMProvider
@@ -14,6 +24,29 @@ from .providers.mistral import MistralProvider
 from .providers.openai import OpenAIProvider
 from .providers.together import TogetherProvider
 from .providers.xai import XAIProvider
+
+# Registry for API keys by provider class
+_PROVIDER_API_KEYS: dict[Type[BaseLLMProvider], str] = {}
+
+# Mapping from provider name strings to provider classes
+_PROVIDER_NAME_TO_CLASS: dict[str, Type[BaseLLMProvider]] = {
+    "openai": OpenAIProvider,
+    "anthropic": AnthropicProvider,
+    "google": GoogleProvider,
+    "xai": XAIProvider,
+    "together": TogetherProvider,
+    "mistral": MistralProvider,
+}
+
+# Mapping from provider classes to GCP secret names
+_PROVIDER_CLASS_TO_SECRET_NAME: dict[Type[BaseLLMProvider], str] = {
+    OpenAIProvider: OPENAI_API_KEY_SECRET_NAME,
+    AnthropicProvider: ANTHROPIC_API_KEY_SECRET_NAME,
+    GoogleProvider: GOOGLE_GEMINI_API_KEY_SECRET_NAME,
+    XAIProvider: XAI_API_KEY_SECRET_NAME,
+    TogetherProvider: TOGETHER_API_KEY_SECRET_NAME,
+    MistralProvider: MISTRAL_API_KEY_SECRET_NAME,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,10 +68,112 @@ class Model:
         return provider.get_response(self, prompt, **options)
 
 
+def _get_api_key_for_provider(provider_cls: Type[BaseLLMProvider]) -> str | None:
+    """Look up API key for a provider from the registry configuration.
+
+    Returns:
+        API key string if configured, None otherwise.
+    """
+    return _PROVIDER_API_KEYS.get(provider_cls)
+
+
 @lru_cache(maxsize=None)
 def _get_provider_instance(provider_cls: Type[BaseLLMProvider]) -> BaseLLMProvider:
     """Return a cached provider instance for the given provider class."""
+    api_key = _get_api_key_for_provider(provider_cls)
+    if api_key is not None:
+        return provider_cls(api_key=api_key)
     return provider_cls()
+
+
+def configure_api_keys(
+    *,
+    from_gcp: bool = False,
+    openai: str | None = None,
+    anthropic: str | None = None,
+    google: str | None = None,
+    xai: str | None = None,
+    together: str | None = None,
+    mistral: str | None = None,
+) -> None:
+    """Configure API keys for LLM providers.
+
+    This function allows you to set API keys either explicitly or by loading them
+    from GCP Secret Manager. Once configured, these keys will be used automatically
+    when providers are instantiated through the model registry.
+
+    Args:
+        from_gcp: If True, load all API keys from GCP Secret Manager. If False,
+            only the explicitly provided keys will be configured.
+        openai: OpenAI API key (e.g., "sk-...")
+        anthropic: Anthropic API key (e.g., "sk-ant-...")
+        google: Google Gemini API key
+        xai: xAI API key
+        together: Together AI API key
+        mistral: Mistral API key
+
+    Examples:
+        # For non-GCP users:
+        configure_api_keys(openai="sk-...", anthropic="sk-ant-...")
+
+        # For GCP users:
+        configure_api_keys(from_gcp=True)
+
+        # Mixed: some explicit, some from GCP
+        configure_api_keys(from_gcp=True, openai="custom-key")
+    """
+    if from_gcp:
+        # Load all keys from GCP Secret Manager
+        for provider_cls, secret_name in _PROVIDER_CLASS_TO_SECRET_NAME.items():
+            try:
+                api_key = get_secret(secret_name)
+                _PROVIDER_API_KEYS[provider_cls] = api_key
+            except RuntimeError:
+                # GCP not configured or secret doesn't exist, skip this provider
+                pass
+
+    # Set explicitly provided keys (these override GCP keys if both are set)
+    key_mapping = {
+        "openai": (OpenAIProvider, openai),
+        "anthropic": (AnthropicProvider, anthropic),
+        "google": (GoogleProvider, google),
+        "xai": (XAIProvider, xai),
+        "together": (TogetherProvider, together),
+        "mistral": (MistralProvider, mistral),
+    }
+
+    for provider_cls, api_key in key_mapping.values():
+        if api_key is not None:
+            _PROVIDER_API_KEYS[provider_cls] = api_key
+
+    # Clear the provider instance cache since keys have changed
+    _get_provider_instance.cache_clear()
+
+
+def validate_provider_keys(models: list[Model]) -> None:
+    """Validate that all providers needed by the given models have API keys configured.
+
+    Args:
+        models: List of Model objects to validate.
+
+    Raises:
+        ValueError: If any model's provider lacks a configured API key.
+    """
+    missing_keys = []
+    provider_names = {cls: name for name, cls in _PROVIDER_NAME_TO_CLASS.items()}
+
+    for model in models:
+        provider_cls = model.provider_cls
+        if provider_cls not in _PROVIDER_API_KEYS:
+            provider_name = provider_names.get(provider_cls, provider_cls.__name__)
+            missing_keys.append(f"{provider_name} (for model {model.id})")
+
+    if missing_keys:
+        missing_list = ", ".join(missing_keys)
+        raise ValueError(
+            f"API keys not configured for the following providers: {missing_list}. "
+            "Call configure_api_keys() or configure_api_keys(from_gcp=True) to set them."
+        )
 
 
 MODELS: Final[list[Model]] = [
@@ -48,13 +183,6 @@ MODELS: Final[list[Model]] = [
         token_limit=128_000,
         provider_cls=OpenAIProvider,
         lab=LABS["OpenAI"],
-    ),
-    Model(
-        id="Qwen2.5-Coder-32B-Instruct",
-        full_name="Qwen/Qwen2.5-Coder-32B-Instruct",
-        token_limit=262_144,
-        provider_cls=TogetherProvider,
-        lab=LABS["Qwen"],
     ),
     Model(
         id="gpt-5-2025-08-07",
@@ -101,6 +229,13 @@ MODELS: Final[list[Model]] = [
         token_limit=128_000,
         provider_cls=TogetherProvider,
         lab=LABS["DeepSeek"],
+    ),
+    Model(
+        id="Qwen2.5-Coder-32B-Instruct",
+        full_name="Qwen/Qwen2.5-Coder-32B-Instruct",
+        token_limit=262_144,
+        provider_cls=TogetherProvider,
+        lab=LABS["Qwen"],
     ),
     Model(
         id="Qwen3-235B-A22B-fp8-tput",

--- a/llm/providers/google.py
+++ b/llm/providers/google.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Any, Dict
 from google import genai
 from google.genai import types
 
-from ...helpers.constants import GOOGLE_GEMINI_API_KEY_SECRET_NAME
-from ...keys.secrets import get_secret
 from .base import BaseLLMProvider
 
 if TYPE_CHECKING:
@@ -20,10 +18,22 @@ class GoogleProvider(BaseLLMProvider):
 
     rate_limit_message = "Google AI API request exceeded rate limit."
 
-    def __init__(self) -> None:
-        """Instantiate the Google client using the configured API secret."""
-        super().__init__()
-        api_key = get_secret(GOOGLE_GEMINI_API_KEY_SECRET_NAME)
+    def __init__(self, *, api_key: str | None = None, default_wait_time: int | None = None) -> None:
+        """Instantiate the Google client using the provided API key.
+
+        Args:
+            api_key: Google Gemini API key. If None, an error will be raised.
+            default_wait_time: Optional custom backoff interval.
+
+        Raises:
+            ValueError: If api_key is None.
+        """
+        super().__init__(default_wait_time=default_wait_time)
+        if api_key is None:
+            raise ValueError(
+                "API key required for GoogleProvider. "
+                "Call configure_api_keys() or provide api_key parameter."
+            )
         self._google_ai_client = genai.Client(api_key=api_key)
 
     def _call_model(self, model: "Model", prompt: str, **options: Any) -> str:

--- a/llm/providers/mistral.py
+++ b/llm/providers/mistral.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from mistralai import Mistral, UserMessage  # type: ignore[import]
 
-from ...helpers.constants import MISTRAL_API_KEY_SECRET_NAME
-from ...keys.secrets import get_secret
 from .base import BaseLLMProvider
 
 if TYPE_CHECKING:
@@ -19,10 +17,22 @@ class MistralProvider(BaseLLMProvider):
 
     rate_limit_message = "Mistral API request exceeded rate limit."
 
-    def __init__(self) -> None:
-        """Instantiate the Mistral client using the configured API secret."""
-        super().__init__()
-        api_key = get_secret(MISTRAL_API_KEY_SECRET_NAME)
+    def __init__(self, *, api_key: str | None = None, default_wait_time: int | None = None) -> None:
+        """Instantiate the Mistral client using the provided API key.
+
+        Args:
+            api_key: Mistral API key. If None, an error will be raised.
+            default_wait_time: Optional custom backoff interval.
+
+        Raises:
+            ValueError: If api_key is None.
+        """
+        super().__init__(default_wait_time=default_wait_time)
+        if api_key is None:
+            raise ValueError(
+                "API key required for MistralProvider. "
+                "Call configure_api_keys() or provide api_key parameter."
+            )
         self._mistral_client = Mistral(api_key=api_key)
 
     def _call_model(self, model: "Model", prompt: str, **options: Any) -> str:

--- a/llm/providers/openai.py
+++ b/llm/providers/openai.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from openai import OpenAI  # type: ignore[import]
 
-from ...helpers.constants import OPENAI_API_KEY_SECRET_NAME
-from ...keys.secrets import get_secret
 from .base import BaseLLMProvider
 
 if TYPE_CHECKING:
@@ -19,10 +17,22 @@ class OpenAIProvider(BaseLLMProvider):
 
     rate_limit_message = "OpenAI API request exceeded rate limit."
 
-    def __init__(self) -> None:
-        """Instantiate the OpenAI client using the configured API secret."""
-        super().__init__()
-        api_key = get_secret(OPENAI_API_KEY_SECRET_NAME)
+    def __init__(self, *, api_key: str | None = None, default_wait_time: int | None = None) -> None:
+        """Instantiate the OpenAI client using the provided API key.
+
+        Args:
+            api_key: OpenAI API key (e.g., "sk-..."). If None, an error will be raised.
+            default_wait_time: Optional custom backoff interval.
+
+        Raises:
+            ValueError: If api_key is None.
+        """
+        super().__init__(default_wait_time=default_wait_time)
+        if api_key is None:
+            raise ValueError(
+                "API key required for OpenAIProvider. "
+                "Call configure_api_keys() or provide api_key parameter."
+            )
         self._openai_client = OpenAI(api_key=api_key)
 
     def _call_model(self, model: "Model", prompt: str, **options: Any) -> str:

--- a/llm/providers/together.py
+++ b/llm/providers/together.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, Union
 
 from together import Together  # type: ignore[import]
 
-from ...helpers.constants import TOGETHER_API_KEY_SECRET_NAME
-from ...keys.secrets import get_secret
 from .base import BaseLLMProvider
 
 if TYPE_CHECKING:
@@ -36,10 +34,22 @@ class TogetherProvider(BaseLLMProvider):
 
     rate_limit_message = "Together AI API request exceeded rate limit."
 
-    def __init__(self) -> None:
-        """Instantiate the Together AI client using the configured API secret."""
-        super().__init__()
-        api_key = get_secret(TOGETHER_API_KEY_SECRET_NAME)
+    def __init__(self, *, api_key: str | None = None, default_wait_time: int | None = None) -> None:
+        """Instantiate the Together AI client using the provided API key.
+
+        Args:
+            api_key: Together AI API key. If None, an error will be raised.
+            default_wait_time: Optional custom backoff interval.
+
+        Raises:
+            ValueError: If api_key is None.
+        """
+        super().__init__(default_wait_time=default_wait_time)
+        if api_key is None:
+            raise ValueError(
+                "API key required for TogetherProvider. "
+                "Call configure_api_keys() or provide api_key parameter."
+            )
         self._together_client = Together(api_key=api_key)
 
     def _call_model(self, model: "Model", prompt: str, **options: Any) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "anthropic",
     "mistralai",
     "together",
+    "openai",
     "google-cloud-secret-manager>=2.20.0",
     "google-cloud-storage>=2.14.0",
     "python-dotenv>=1.0.0",
@@ -41,8 +42,6 @@ include = [
     "gcp.*",
     "helpers",
     "helpers.*",
-    "keys",
-    "keys.*",
     "llm",
     "llm.*",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ flake8-bugbear
 pydocstyle
 pytest
 pytest-cov
+pytest-xdist
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,28 @@ load_dotenv(
 )
 
 
+@pytest.fixture(scope="session", autouse=True)
+def configure_llm_api_keys(request):
+    """Auto-configure LLM API keys from GCP for integration tests.
+
+    Uses session scope to cache API keys across all integration tests,
+    avoiding redundant GCP Secret Manager calls.
+    """
+    # Only configure if we're running integration tests
+    # Check if any test has the integration marker (check config instead of individual test)
+    config = request.config
+    if config.getoption("--integration"):
+        try:
+            from utils.llm.model_registry import (
+                configure_api_keys,  # type: ignore[import]
+            )
+
+            configure_api_keys(from_gcp=True)
+        except Exception:
+            # If GCP is not configured, skip this fixture
+            pass
+
+
 def pytest_addoption(parser):
     """Register the custom --integration flag."""
     parser.addoption(

--- a/tests/integration/llm/providers/test_anthropic.py
+++ b/tests/integration/llm/providers/test_anthropic.py
@@ -18,7 +18,15 @@ assert ANTHROPIC_MODEL is not None
 @pytest.mark.integration
 def test_anthropic_provider_get_response_live_call():
     """It invokes the live Anthropic API and returns text."""
-    provider = anthropic_module.AnthropicProvider()
+    from utils.llm.model_registry import (
+        _get_api_key_for_provider,  # type: ignore[import]
+    )
+    from utils.llm.providers.anthropic import AnthropicProvider  # type: ignore[import]
+
+    # API keys are already configured by the session-scoped fixture
+    api_key = _get_api_key_for_provider(AnthropicProvider)
+    assert api_key is not None, "API key should be configured by fixture"
+    provider = anthropic_module.AnthropicProvider(api_key=api_key)
     assert_capital_of_france(
         lambda prompt: provider.get_response(
             ANTHROPIC_MODEL,

--- a/tests/integration/llm/providers/test_google.py
+++ b/tests/integration/llm/providers/test_google.py
@@ -18,7 +18,15 @@ assert GOOGLE_MODEL is not None
 @pytest.mark.integration
 def test_google_provider_get_response_live_call():
     """It invokes the live Google Gemini API and returns text."""
-    provider = google_module.GoogleProvider()
+    from utils.llm.model_registry import (
+        _get_api_key_for_provider,  # type: ignore[import]
+    )
+    from utils.llm.providers.google import GoogleProvider  # type: ignore[import]
+
+    # API keys are already configured by the session-scoped fixture
+    api_key = _get_api_key_for_provider(GoogleProvider)
+    assert api_key is not None, "API key should be configured by fixture"
+    provider = google_module.GoogleProvider(api_key=api_key)
     assert_capital_of_france(
         lambda prompt: provider.get_response(
             GOOGLE_MODEL,

--- a/tests/integration/llm/providers/test_mistral.py
+++ b/tests/integration/llm/providers/test_mistral.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pytest
 import utils.llm.providers.mistral as mistral_module  # type: ignore[import]
-from utils.llm.model_registry import Model  # type: ignore[import]
 from utils.llm.model_registry import MODELS  # type: ignore[import]
+from utils.llm.model_registry import Model  # type: ignore[import]
 from utils.tests.integration.helpers import (
     assert_capital_of_france,  # type: ignore[import]
 )
@@ -19,7 +19,15 @@ assert MISTRAL_MODEL is not None
 @pytest.mark.integration
 def test_mistral_provider_get_response_live_call():
     """It invokes the live Mistral API and returns text."""
-    provider = mistral_module.MistralProvider()
+    from utils.llm.model_registry import (
+        _get_api_key_for_provider,  # type: ignore[import]
+    )
+    from utils.llm.providers.mistral import MistralProvider  # type: ignore[import]
+
+    # API keys are already configured by the session-scoped fixture
+    api_key = _get_api_key_for_provider(MistralProvider)
+    assert api_key is not None, "API key should be configured by fixture"
+    provider = mistral_module.MistralProvider(api_key=api_key)
     assert_capital_of_france(
         lambda prompt: provider.get_response(
             MISTRAL_MODEL,

--- a/tests/integration/llm/providers/test_openai.py
+++ b/tests/integration/llm/providers/test_openai.py
@@ -18,7 +18,15 @@ assert OPENAI_MODEL is not None
 @pytest.mark.integration
 def test_openai_provider_get_response_live_call():
     """It invokes the live OpenAI API and returns text."""
-    provider = openai_module.OpenAIProvider()
+    from utils.llm.model_registry import (
+        _get_api_key_for_provider,  # type: ignore[import]
+    )
+    from utils.llm.providers.openai import OpenAIProvider  # type: ignore[import]
+
+    # API keys are already configured by the session-scoped fixture
+    api_key = _get_api_key_for_provider(OpenAIProvider)
+    assert api_key is not None, "API key should be configured by fixture"
+    provider = openai_module.OpenAIProvider(api_key=api_key)
     assert_capital_of_france(
         lambda prompt: provider.get_response(
             OPENAI_MODEL,

--- a/tests/integration/llm/providers/test_together.py
+++ b/tests/integration/llm/providers/test_together.py
@@ -18,7 +18,15 @@ assert TOGETHER_MODEL is not None
 @pytest.mark.integration
 def test_together_provider_get_response_live_call():
     """It invokes the live Together AI API and returns text."""
-    provider = together_module.TogetherProvider()
+    from utils.llm.model_registry import (
+        _get_api_key_for_provider,  # type: ignore[import]
+    )
+    from utils.llm.providers.together import TogetherProvider  # type: ignore[import]
+
+    # API keys are already configured by the session-scoped fixture
+    api_key = _get_api_key_for_provider(TogetherProvider)
+    assert api_key is not None, "API key should be configured by fixture"
+    provider = together_module.TogetherProvider(api_key=api_key)
     assert_capital_of_france(
         lambda prompt: provider.get_response(
             TOGETHER_MODEL,

--- a/tests/integration/llm/providers/test_xai.py
+++ b/tests/integration/llm/providers/test_xai.py
@@ -16,7 +16,15 @@ assert XAI_MODEL is not None
 @pytest.mark.integration
 def test_xai_provider_get_response_live_call():
     """It invokes the live xAI API and returns text."""
-    provider = xai_module.XAIProvider()
+    from utils.llm.model_registry import (
+        _get_api_key_for_provider,  # type: ignore[import]
+    )
+    from utils.llm.providers.xai import XAIProvider  # type: ignore[import]
+
+    # API keys are already configured by the session-scoped fixture
+    api_key = _get_api_key_for_provider(XAIProvider)
+    assert api_key is not None, "API key should be configured by fixture"
+    provider = xai_module.XAIProvider(api_key=api_key)
     assert_capital_of_france(
         lambda prompt: provider.get_response(
             XAI_MODEL,

--- a/tests/integration/test_keys_integration.py
+++ b/tests/integration/test_keys_integration.py
@@ -26,25 +26,10 @@ def test_get_secret_integration(monkeypatch):
     credentials_path = os.environ.get(GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR)
     assert credentials_path is not None
 
-    secrets_module = import_module("utils.keys.secrets")
+    secrets_module = import_module("utils.gcp.secret_manager")
 
     value = secrets_module.get_secret(ANTHROPIC_API_KEY_SECRET_NAME)
     assert value is not None and value != ""
 
     with pytest.raises(gcloud_exceptions.NotFound):
         secrets_module.get_secret(unique_secret_name)
-
-
-@pytest.mark.integration
-def test_get_secret_that_may_not_exist_integration_missing(monkeypatch):
-    """Integration check that missing secrets return None instead of raising."""
-    project_id = os.environ.get(GOOGLE_CLOUD_PROJECT_ENV_VAR)
-    assert project_id is not None
-    credentials_path = os.environ.get(GOOGLE_APPLICATION_CREDENTIALS_ENV_VAR)
-    assert credentials_path is not None
-
-    secrets_module = import_module("utils.keys.secrets")
-
-    value = secrets_module.get_secret_that_may_not_exist(unique_secret_name)
-
-    assert value is None

--- a/tests/unit/test_keys.py
+++ b/tests/unit/test_keys.py
@@ -4,20 +4,19 @@ from importlib import import_module, reload
 from unittest.mock import MagicMock, patch
 
 import pytest
-from google.api_core import exceptions as gcloud_exceptions
 from utils.helpers.constants import GOOGLE_CLOUD_PROJECT_ENV_VAR
 
 
 def _reload_secrets(monkeypatch):
     """Reload the secrets module with the desired environment."""
     monkeypatch.setenv(GOOGLE_CLOUD_PROJECT_ENV_VAR, "test-project")
-    secrets_module = import_module("utils.keys.secrets")
+    secrets_module = import_module("utils.gcp.secret_manager")
 
     reloaded_secrets = reload(secrets_module)
     return reloaded_secrets
 
 
-@patch("utils.keys.secrets.secretmanager.SecretManagerServiceClient")
+@patch("utils.gcp.secret_manager.secretmanager.SecretManagerServiceClient")
 def test_get_secret_returns_decoded_payload(mock_client_class, monkeypatch):
     """It returns the decoded payload when Secret Manager responds with bytes."""
     secrets_module = _reload_secrets(monkeypatch)
@@ -36,7 +35,7 @@ def test_get_secret_returns_decoded_payload(mock_client_class, monkeypatch):
     )
 
 
-@patch("utils.keys.secrets.secretmanager.SecretManagerServiceClient")
+@patch("utils.gcp.secret_manager.secretmanager.SecretManagerServiceClient")
 def test_get_secret_raises_type_error_for_non_bytes_payload(mock_client_class, monkeypatch):
     """It raises TypeError if Secret Manager returns a non-bytes payload."""
     secrets_module = _reload_secrets(monkeypatch)
@@ -49,17 +48,3 @@ def test_get_secret_raises_type_error_for_non_bytes_payload(mock_client_class, m
 
     with pytest.raises(TypeError):
         secrets_module.get_secret("api-key")
-
-
-@patch("utils.keys.secrets.secretmanager.SecretManagerServiceClient")
-def test_get_secret_that_may_not_exist_returns_none_when_missing(mock_client_class, monkeypatch):
-    """It returns None when the secret version is missing."""
-    secrets_module = _reload_secrets(monkeypatch)
-
-    mock_client = MagicMock()
-    mock_client.access_secret_version.side_effect = gcloud_exceptions.NotFound("missing")
-    mock_client_class.return_value = mock_client
-
-    result = secrets_module.get_secret_that_may_not_exist("missing-secret")
-
-    assert result is None

--- a/tests/unit/test_model_registry_config.py
+++ b/tests/unit/test_model_registry_config.py
@@ -1,0 +1,210 @@
+"""Unit tests for model registry API key configuration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from utils.llm.model_registry import (  # type: ignore[import]
+    MODELS,
+    AnthropicProvider,
+    GoogleProvider,
+    MistralProvider,
+    OpenAIProvider,
+    TogetherProvider,
+    XAIProvider,
+    configure_api_keys,
+    validate_provider_keys,
+)
+
+
+def test_configure_api_keys_with_explicit_keys():
+    """Test configure_api_keys() with explicitly provided keys."""
+    from utils.llm.model_registry import _PROVIDER_API_KEYS  # type: ignore[import]
+
+    # Clear any existing keys first
+    _PROVIDER_API_KEYS.clear()
+
+    configure_api_keys(
+        openai="sk-test-openai",
+        anthropic="sk-ant-test-anthropic",
+        google="test-google",
+        xai="test-xai",
+        together="test-together",
+        mistral="test-mistral",
+    )
+
+    # Verify keys are stored
+    assert _PROVIDER_API_KEYS[OpenAIProvider] == "sk-test-openai"
+    assert _PROVIDER_API_KEYS[AnthropicProvider] == "sk-ant-test-anthropic"
+    assert _PROVIDER_API_KEYS[GoogleProvider] == "test-google"
+    assert _PROVIDER_API_KEYS[XAIProvider] == "test-xai"
+    assert _PROVIDER_API_KEYS[TogetherProvider] == "test-together"
+    assert _PROVIDER_API_KEYS[MistralProvider] == "test-mistral"
+
+    # Clear for other tests
+    _PROVIDER_API_KEYS.clear()
+
+
+def test_configure_api_keys_partial():
+    """Test configure_api_keys() with only some keys provided."""
+    from utils.llm.model_registry import _PROVIDER_API_KEYS  # type: ignore[import]
+
+    # Clear any existing keys first
+    _PROVIDER_API_KEYS.clear()
+
+    configure_api_keys(openai="sk-test-openai", anthropic="sk-ant-test-anthropic")
+
+    assert _PROVIDER_API_KEYS[OpenAIProvider] == "sk-test-openai"
+    assert _PROVIDER_API_KEYS[AnthropicProvider] == "sk-ant-test-anthropic"
+    assert GoogleProvider not in _PROVIDER_API_KEYS
+
+    # Clear for other tests
+    _PROVIDER_API_KEYS.clear()
+
+
+@patch("utils.llm.model_registry.get_secret")
+def test_configure_api_keys_from_gcp(mock_get_secret):
+    """Test configure_api_keys(from_gcp=True) loads keys from GCP."""
+    from utils.llm.model_registry import _PROVIDER_API_KEYS  # type: ignore[import]
+
+    # Clear any existing keys first
+    _PROVIDER_API_KEYS.clear()
+
+    # Mock GCP secret manager responses
+    mock_get_secret.side_effect = {
+        "API_KEY_OPENAI": "sk-gcp-openai",
+        "API_KEY_ANTHROPIC": "sk-ant-gcp-anthropic",
+        "API_KEY_GEMINI": "gcp-google",
+        "API_KEY_XAI": "gcp-xai",
+        "API_KEY_TOGETHERAI": "gcp-together",
+        "API_KEY_MISTRAL": "gcp-mistral",
+    }.get
+
+    configure_api_keys(from_gcp=True)
+
+    assert _PROVIDER_API_KEYS[OpenAIProvider] == "sk-gcp-openai"
+    assert _PROVIDER_API_KEYS[AnthropicProvider] == "sk-ant-gcp-anthropic"
+    assert _PROVIDER_API_KEYS[GoogleProvider] == "gcp-google"
+    assert _PROVIDER_API_KEYS[XAIProvider] == "gcp-xai"
+    assert _PROVIDER_API_KEYS[TogetherProvider] == "gcp-together"
+    assert _PROVIDER_API_KEYS[MistralProvider] == "gcp-mistral"
+
+    # Clear for other tests
+    _PROVIDER_API_KEYS.clear()
+
+
+@patch("utils.llm.model_registry.get_secret")
+def test_configure_api_keys_from_gcp_handles_missing_secrets(mock_get_secret):
+    """Test configure_api_keys(from_gcp=True) handles missing GCP secrets gracefully."""
+    from utils.llm.model_registry import _PROVIDER_API_KEYS  # type: ignore[import]
+
+    # Clear any existing keys first
+    _PROVIDER_API_KEYS.clear()
+
+    # Mock some secrets existing, some missing
+    def mock_get_secret_side_effect(secret_name: str) -> str:
+        if secret_name == "API_KEY_OPENAI":
+            return "sk-gcp-openai"
+        elif secret_name == "API_KEY_ANTHROPIC":
+            raise RuntimeError("GCP not configured")
+        else:
+            raise RuntimeError("Secret not found")
+
+    mock_get_secret.side_effect = mock_get_secret_side_effect
+
+    configure_api_keys(from_gcp=True)
+
+    # Only OpenAI should be configured
+    assert _PROVIDER_API_KEYS[OpenAIProvider] == "sk-gcp-openai"
+    assert AnthropicProvider not in _PROVIDER_API_KEYS
+
+    # Clear for other tests
+    _PROVIDER_API_KEYS.clear()
+
+
+def test_configure_api_keys_explicit_overrides_gcp():
+    """Test that explicitly provided keys override GCP keys."""
+    from utils.llm.model_registry import _PROVIDER_API_KEYS  # type: ignore[import]
+
+    # Clear any existing keys first
+    _PROVIDER_API_KEYS.clear()
+
+    with patch("utils.llm.model_registry.get_secret") as mock_get_secret:
+        mock_get_secret.return_value = "sk-gcp-openai"
+
+        configure_api_keys(from_gcp=True, openai="sk-explicit-openai")
+
+        # Explicit key should override GCP key
+        assert _PROVIDER_API_KEYS[OpenAIProvider] == "sk-explicit-openai"
+
+        # Clear for other tests
+        _PROVIDER_API_KEYS.clear()
+
+
+def test_validate_provider_keys_success():
+    """Test validate_provider_keys() succeeds when all keys are configured."""
+    from utils.llm.model_registry import _PROVIDER_API_KEYS  # type: ignore[import]
+
+    # Clear any existing keys first
+    _PROVIDER_API_KEYS.clear()
+
+    configure_api_keys(
+        openai="sk-test-openai",
+        anthropic="sk-ant-test-anthropic",
+        google="test-google",
+        xai="test-xai",
+        together="test-together",
+        mistral="test-mistral",
+    )
+
+    # Should not raise
+    validate_provider_keys(MODELS)
+
+    # Clear for other tests
+    _PROVIDER_API_KEYS.clear()
+
+
+def test_validate_provider_keys_raises_on_missing():
+    """Test validate_provider_keys() raises when keys are missing."""
+    from utils.llm.model_registry import _PROVIDER_API_KEYS  # type: ignore[import]
+
+    _PROVIDER_API_KEYS.clear()
+
+    configure_api_keys(openai="sk-test-openai")
+
+    # Should raise because other providers are missing
+    with pytest.raises(ValueError, match="API keys not configured"):
+        validate_provider_keys(MODELS)
+
+    # Clear for other tests
+    _PROVIDER_API_KEYS.clear()
+
+
+def test_configure_api_keys_clears_provider_cache():
+    """Test that configure_api_keys() clears the provider instance cache."""
+    from utils.llm.model_registry import (  # type: ignore[import]
+        _PROVIDER_API_KEYS,
+        _get_provider_instance,
+    )
+
+    # Clear any existing keys first
+    _PROVIDER_API_KEYS.clear()
+
+    # Configure initial keys
+    configure_api_keys(openai="sk-test-1")
+
+    # Get an instance (will be cached)
+    instance1 = _get_provider_instance(OpenAIProvider)
+
+    # Configure different keys
+    configure_api_keys(openai="sk-test-2")
+
+    # Get instance again - should be new instance with new key
+    instance2 = _get_provider_instance(OpenAIProvider)
+
+    # Instances should be different (cache was cleared)
+    assert instance1 is not instance2
+
+    # Clear for other tests
+    _PROVIDER_API_KEYS.clear()

--- a/tests/unit/test_provider_api_keys.py
+++ b/tests/unit/test_provider_api_keys.py
@@ -1,0 +1,88 @@
+"""Unit tests for LLM provider API key handling."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from utils.llm.providers.anthropic import AnthropicProvider  # type: ignore[import]
+from utils.llm.providers.google import GoogleProvider  # type: ignore[import]
+from utils.llm.providers.mistral import MistralProvider  # type: ignore[import]
+from utils.llm.providers.openai import OpenAIProvider  # type: ignore[import]
+from utils.llm.providers.together import TogetherProvider  # type: ignore[import]
+from utils.llm.providers.xai import XAIProvider  # type: ignore[import]
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    [
+        OpenAIProvider,
+        AnthropicProvider,
+        GoogleProvider,
+        XAIProvider,
+        MistralProvider,
+        TogetherProvider,
+    ],
+)
+def test_provider_requires_api_key(provider_class):
+    """Test that providers raise ValueError when api_key is None."""
+    with pytest.raises(ValueError, match="API key required"):
+        provider_class(api_key=None)
+
+
+@pytest.mark.parametrize(
+    "provider_class,api_key",
+    [
+        (OpenAIProvider, "sk-test-openai-key"),
+        (AnthropicProvider, "sk-ant-test-anthropic-key"),
+        (GoogleProvider, "test-google-key"),
+        (XAIProvider, "test-xai-key"),
+        (MistralProvider, "test-mistral-key"),
+        (TogetherProvider, "test-together-key"),
+    ],
+)
+def test_provider_accepts_api_key(provider_class, api_key):
+    """Test that providers can be instantiated with explicit API keys."""
+    # Mock the underlying client initialization
+    if provider_class == OpenAIProvider:
+        with patch("utils.llm.providers.openai.OpenAI") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+            provider = provider_class(api_key=api_key)
+            mock_openai.assert_called_once_with(api_key=api_key)
+            assert provider is not None
+    elif provider_class == AnthropicProvider:
+        with patch("anthropic.Anthropic") as mock_anthropic:
+            mock_client = MagicMock()
+            mock_anthropic.return_value = mock_client
+            provider = provider_class(api_key=api_key)
+            mock_anthropic.assert_called_once_with(api_key=api_key)
+            assert provider is not None
+    elif provider_class == GoogleProvider:
+        with patch("utils.llm.providers.google.genai.Client") as mock_client:
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+            provider = provider_class(api_key=api_key)
+            mock_client.assert_called_once_with(api_key=api_key)
+            assert provider is not None
+    elif provider_class == XAIProvider:
+        with patch("utils.llm.providers.xai.openai.OpenAI") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+            provider = provider_class(api_key=api_key)
+            mock_openai.assert_called_once_with(api_key=api_key, base_url="https://api.x.ai/v1")
+            assert provider is not None
+    elif provider_class == MistralProvider:
+        with patch("utils.llm.providers.mistral.Mistral") as mock_mistral:
+            mock_client = MagicMock()
+            mock_mistral.return_value = mock_client
+            provider = provider_class(api_key=api_key)
+            mock_mistral.assert_called_once_with(api_key=api_key)
+            assert provider is not None
+    elif provider_class == TogetherProvider:
+        with patch("utils.llm.providers.together.Together") as mock_together:
+            mock_client = MagicMock()
+            mock_together.return_value = mock_client
+            provider = provider_class(api_key=api_key)
+            mock_together.assert_called_once_with(api_key=api_key)
+            assert provider is not None


### PR DESCRIPTION
This PR decouples GCP from our API key infrastructure, closing #9.

My strategy was to create a unified API, regardless of whether the caller is using GCP or not.

In the individual-API-key case:

```python
from utils.llm.model_registry import configure_api_keys, MODELS

configure_api_keys(openai="sk-...", anthropic="sk-ant-...")
model = next(m for m in MODELS if m.id == "gpt-4.1-mini")
response = model.get_response("Hello")
```

This is a common, easy-to-set-up approach for people with API keys to just a few providers.

In the GCP case - helpful when someone needs access to *all the models*:

```python
from utils.llm.model_registry import configure_api_keys, MODELS

configure_api_keys(from_gcp=True)  # Loads all keys from GCP
model = next(m for m in MODELS if m.id == "gpt-4.1-mini")
response = model.get_response("Hello")
```

This is a “convention-over-configuration” approach - all API keys are assumed to be stored by the names provided in `constants.py`.


## Minor fixes

This PR also introduces a few minor fixes:

- Improved pip compatibility.
- Closed #5
- Closed #8
- Fixed hang on unit tests
- Sped up provider integration tests
- Added optional parallel integration testing with `make test-integratio-parallel`
- Patched a minor bug in the Anthropic provider