### PR TITLE
Add new LLM models and improve Mistral provider

### DIFF
--- a/tests/integration/llm/test_model_registry.py
+++ b/tests/integration/llm/test_model_registry.py
@@ -17,7 +17,7 @@ def test_registered_model_live_call(model: Model):
         lambda prompt: model.get_response(
             prompt,
             temperature=0,
-            max_tokens=256,
+            max_tokens=1024,
             wait_time=1,
         )
     )

--- a/utils/llm/model_registry.py
+++ b/utils/llm/model_registry.py
@@ -208,6 +208,14 @@ MODELS: Final[list[Model]] = [
         reasoning_model=True,
     ),
     Model(
+        id="gpt-5.1-2025-11-13",
+        full_name="gpt-5.1-2025-11-13",
+        token_limit=128_000,
+        provider_cls=OpenAIProvider,
+        lab=LABS["OpenAI"],
+        reasoning_model=True,
+    ),
+    Model(
         id="o3-2025-04-16",
         full_name="o3-2025-04-16",
         token_limit=200_000,
@@ -229,13 +237,14 @@ MODELS: Final[list[Model]] = [
         provider_cls=TogetherProvider,
         lab=LABS["DeepSeek"],
     ),
-    Model(
-        id="Qwen2.5-Coder-32B-Instruct",
-        full_name="Qwen/Qwen2.5-Coder-32B-Instruct",
-        token_limit=262_144,
-        provider_cls=TogetherProvider,
-        lab=LABS["Qwen"],
-    ),
+    # NOTE: This model is no longer available in the Together API.
+    # Model(
+    #     id="Qwen2.5-Coder-32B-Instruct",
+    #     full_name="Qwen/Qwen2.5-Coder-32B-Instruct",
+    #     token_limit=262_144,
+    #     provider_cls=TogetherProvider,
+    #     lab=LABS["Qwen"],
+    # ),
     Model(
         id="Qwen3-235B-A22B-fp8-tput",
         full_name="Qwen/Qwen3-235B-A22B-fp8-tput",
@@ -265,11 +274,27 @@ MODELS: Final[list[Model]] = [
         lab=LABS["Moonshot"],
     ),
     Model(
+        id="Kimi-K2-Thinking",
+        full_name="moonshotai/Kimi-K2-Thinking",
+        token_limit=262_144,
+        provider_cls=TogetherProvider,
+        lab=LABS["Moonshot"],
+        reasoning_model=False,
+    ),
+    Model(
         id="GLM-4.5-Air-FP8",
         full_name="zai-org/GLM-4.5-Air-FP8",
         token_limit=131_072,
         provider_cls=TogetherProvider,
         lab=LABS["Z.ai"],
+    ),
+    Model(
+        id="GLM-4.6",
+        full_name="zai-org/GLM-4.6",
+        token_limit=202_752,
+        provider_cls=TogetherProvider,
+        lab=LABS["Z.ai"],
+        reasoning_model=False,
     ),
     Model(
         id="claude-sonnet-4-5-20250929",
@@ -328,6 +353,22 @@ MODELS: Final[list[Model]] = [
         lab=LABS["xAI"],
     ),
     Model(
+        id="grok-4-1-fast-reasoning",
+        full_name="grok-4-1-fast-reasoning",
+        token_limit=2_000_000,
+        provider_cls=XAIProvider,
+        lab=LABS["xAI"],
+        reasoning_model=True,
+    ),
+    Model(
+        id="grok-4-1-fast-non-reasoning",
+        full_name="grok-4-1-fast-non-reasoning",
+        token_limit=2_000_000,
+        provider_cls=XAIProvider,
+        lab=LABS["xAI"],
+        reasoning_model=False,
+    ),
+    Model(
         id="gemini-2.5-pro",
         full_name="gemini-2.5-pro",
         token_limit=1_048_576,
@@ -340,6 +381,14 @@ MODELS: Final[list[Model]] = [
         token_limit=1_048_576,
         provider_cls=GoogleProvider,
         lab=LABS["Google"],
+    ),
+    Model(
+        id="gemini-3-pro-preview",
+        full_name="gemini-3-pro-preview",
+        token_limit=1_048_576,
+        provider_cls=GoogleProvider,
+        lab=LABS["Google"],
+        reasoning_model=False,
     ),
     Model(
         id="mistral-large-2411",

--- a/utils/llm/providers/mistral.py
+++ b/utils/llm/providers/mistral.py
@@ -55,4 +55,23 @@ class MistralProvider(BaseLLMProvider):
 
         chat_response = self._mistral_client.chat.complete(**request_payload)
 
-        return chat_response.choices[0].message.content
+        content = chat_response.choices[0].message.content
+
+        # Handle different content types: None, str, or list
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            # Content can be a list of content blocks, extract text from each
+            text_parts = []
+            for item in content:
+                if isinstance(item, str):
+                    text_parts.append(item)
+                elif isinstance(item, dict) and "text" in item:
+                    text_parts.append(item["text"])
+                else:
+                    text_parts.append(str(item))
+            return "".join(text_parts)
+
+        return str(content)


### PR DESCRIPTION
Adds 6 new models to the registry:

- OpenAI: gpt-5.1-2025-11-13
- Moonshot: Kimi-K2-Thinking
- Z.ai: GLM-4.6
- xAI: grok-4-1-fast-reasoning and grok-4-1-fast-non-reasoning
- Google: gemini-3-pro-preview

Also:
- Comments out deprecated Qwen2.5-Coder-32B-Instruct model (no longer available in Together API)
- Fixes Mistral provider to handle different content response types (None, str, list)
- Updates test max_tokens to 1024 for better coverage
