### PR TITLE
fix(llm): handle NotFound exception when loading secrets from GCP

### DIFF
--- a/tests/unit/test_model_registry_config.py
+++ b/tests/unit/test_model_registry_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from google.api_core import exceptions
 
 from utils.llm.model_registry import (  # type: ignore[import]
     MODELS,
@@ -108,9 +109,9 @@ def test_configure_api_keys_from_gcp_handles_missing_secrets(mock_get_secret):
         if secret_name == "API_KEY_OPENAI":
             return "sk-gcp-openai"
         elif secret_name == "API_KEY_ANTHROPIC":
-            raise RuntimeError("GCP not configured")
+            raise exceptions.NotFound("Secret not found")
         else:
-            raise RuntimeError("Secret not found")
+            raise exceptions.NotFound("Secret not found")
 
     mock_get_secret.side_effect = mock_get_secret_side_effect
 

--- a/utils/llm/model_registry.py
+++ b/utils/llm/model_registry.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Final, Type
 
+from google.api_core import exceptions
+
 from ..gcp.secret_manager import get_secret
 from ..helpers.constants import (
     ANTHROPIC_API_KEY_SECRET_NAME,
@@ -127,7 +129,7 @@ def configure_api_keys(
             try:
                 api_key = get_secret(secret_name)
                 _PROVIDER_API_KEYS[provider_cls] = api_key
-            except RuntimeError:
+            except (RuntimeError, exceptions.NotFound):
                 # GCP not configured or secret doesn't exist, skip this provider
                 pass
 


### PR DESCRIPTION
Previously, `configure_api_keys(from_gcp=True)` would raise `google.api_core.exceptions.NotFound` when a secret didn't exist in GCP Secret Manager. This caused the entire configuration to fail even if only some providers were missing secrets.

Now the function gracefully skips providers whose secrets don't exist by catching both `RuntimeError` and `NotFound` exceptions.

Fixes #17