### PR TITLE
Add gpt-4o-mini to the model registry

### DIFF
--- a/utils/llm/model_registry.py
+++ b/utils/llm/model_registry.py
@@ -184,6 +184,13 @@ MODELS: Final[list[Model]] = [
         lab=LABS["OpenAI"],
     ),
     Model(
+        id="gpt-4o-mini",
+        full_name="gpt-4o-mini",
+        token_limit=128_000,
+        provider_cls=OpenAIProvider,
+        lab=LABS["OpenAI"],
+    ),
+    Model(
         id="gpt-5-2025-08-07",
         full_name="gpt-5-2025-08-07",
         token_limit=128_000,


### PR DESCRIPTION
Add gpt-4o-mini to the model registry with 128k token limit. This model is used by ForecastBench to parse LLM output.

Closes #19