### PR TITLE
Add new max out model runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "google-genai==2.8.0",
     "anthropic==0.117.0",
     "together==2.23.0",
-    "openai==2.43.0",
+    "openai==2.46.0",
     "google-cloud-secret-manager>=2.20.0",
     "google-cloud-storage>=2.14.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Forecasting Research Institute" }]
 dependencies = [
-    "google-genai==2.8.0",
+    "google-genai==2.13.0",
     "anthropic==0.117.0",
     "together==2.23.0",
     "openai==2.46.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { file = "LICENSE" }
 authors = [{ name = "Forecasting Research Institute" }]
 dependencies = [
     "google-genai==2.8.0",
-    "anthropic==0.109.2",
+    "anthropic==0.117.0",
     "together==2.23.0",
     "openai==2.43.0",
     "google-cloud-secret-manager>=2.20.0",

--- a/tests/unit/test_llm_model_runs.py
+++ b/tests/unit/test_llm_model_runs.py
@@ -112,6 +112,8 @@ HISTORICAL_MODEL_RUN_KEYS = (
     "gpt-5.5-2026-04-23-run-variant-02",
     "gpt-5.5-2026-04-23-run-variant-03",
     "gpt-5.5-2026-04-23-run-variant-04",
+    "gpt-5.6-sol-run-variant-01",
+    "gpt-5.6-sol-run-variant-02",
     "grok-4-0709-run-variant-01",
     "grok-4-1-fast-non-reasoning-run-variant-01",
     "grok-4-1-fast-reasoning-run-variant-01",

--- a/tests/unit/test_llm_model_runs.py
+++ b/tests/unit/test_llm_model_runs.py
@@ -31,6 +31,8 @@ HISTORICAL_MODEL_RUN_KEYS = (
     "claude-3-7-sonnet-20250219-run-variant-01",
     "claude-3-haiku-20240307-run-variant-01",
     "claude-3-opus-20240229-run-variant-01",
+    "claude-fable-5-run-variant-01",
+    "claude-fable-5-run-variant-02",
     "claude-haiku-4-5-20251001-run-variant-01",
     "claude-haiku-4-5-20251001-run-variant-02",
     "claude-opus-4-1-20250805-run-variant-01",
@@ -699,6 +701,29 @@ def test_anthropic_1024_token_runs_use_temperature_only_when_models_dev_supports
     assert invalid_unsupported_temperatures == {}
 
 
+def test_claude_fable_variants_use_effort_fallbacks_and_web_search():
+    """Keep both Fable runs on the intended effort, fallback, and web-search/fetch config."""
+    from utils.llm import model_runs
+
+    shared = {
+        "max_tokens": 128000,
+        "fallbacks": [{"model": "claude-opus-4-8"}],
+        "betas": ["server-side-fallback-2026-06-01"],
+        "tools": [
+            {"type": "web_search_20260318", "name": "web_search"},
+            {"type": "web_fetch_20260318", "name": "web_fetch"},
+        ],
+    }
+
+    high = model_runs.MODEL_RUNS_BY_KEY["claude-fable-5-run-variant-01"]
+    assert high.slug == "claude-fable-5-high-web-search-128k"
+    assert high.options == {**shared, "output_config": {"effort": "high"}}
+
+    max_effort = model_runs.MODEL_RUNS_BY_KEY["claude-fable-5-run-variant-02"]
+    assert max_effort.slug == "claude-fable-5-max-web-search-128k"
+    assert max_effort.options == {**shared, "output_config": {"effort": "max"}}
+
+
 def test_minimax_variants_declare_provider_controls_on_existing_run_keys():
     """Keep MiniMax provider controls on the intended stable run keys."""
     from utils.llm import model_runs
@@ -1053,10 +1078,14 @@ def _declared_option_names_by_provider() -> dict[str, frozenset[str]]:
     from openai import OpenAI
     from together import Together
 
+    anthropic = Anthropic(api_key="test")
+    anthropic_names = _keyword_parameter_names(
+        anthropic.messages.stream
+    ) | _keyword_parameter_names(anthropic.beta.messages.stream)
     openai_names = _keyword_parameter_names(OpenAI(api_key="test").responses.create)
     moonshot_ai_names = _keyword_parameter_names(OpenAI(api_key="test").chat.completions.create)
     return {
-        "Anthropic": _keyword_parameter_names(Anthropic(api_key="test").messages.stream),
+        "Anthropic": anthropic_names,
         "Google": _google_generate_content_config_names(),
         "Moonshot AI": moonshot_ai_names,
         "OpenAI": openai_names,

--- a/tests/unit/test_llm_model_runs.py
+++ b/tests/unit/test_llm_model_runs.py
@@ -79,6 +79,8 @@ HISTORICAL_MODEL_RUN_KEYS = (
     "gemini-3.1-pro-preview-run-variant-03",
     "gemini-3.5-flash-run-variant-01",
     "gemini-3.5-flash-run-variant-02",
+    "gemini-3.6-flash-run-variant-01",
+    "gemini-3.6-flash-run-variant-02",
     "gemma-4-31b-it-run-variant-01",
     "gemma-4-31b-it-run-variant-02",
     "glm-4.5-air-fp8-run-variant-01",

--- a/tests/unit/test_llm_routing.py
+++ b/tests/unit/test_llm_routing.py
@@ -296,6 +296,41 @@ def test_anthropic_provider_route_fields_override_reserved_options():
     )
 
 
+def test_anthropic_provider_uses_beta_messages_for_fallback_options():
+    """Anthropic fallback options should route through the beta Messages API."""
+    from utils.llm.providers.anthropic import AnthropicProvider
+
+    stream = MagicMock()
+    stream.__enter__.return_value = stream
+    stream.get_final_text.return_value = "forecast"
+
+    with patch("anthropic.Anthropic") as mock_anthropic:
+        mock_client = MagicMock()
+        mock_client.beta.messages.stream.return_value = stream
+        mock_anthropic.return_value = mock_client
+
+        provider = AnthropicProvider(api_key="sk-ant-test")
+        text = provider._call_model(
+            model_id="claude-fable-5",
+            prompt="forecast",
+            options={
+                "max_tokens": 16000,
+                "fallbacks": [{"model": "claude-opus-4-8"}],
+                "betas": ["server-side-fallback-2026-06-01"],
+            },
+        )
+
+    assert text == "forecast"
+    mock_client.beta.messages.stream.assert_called_once_with(
+        model="claude-fable-5",
+        messages=[{"role": "user", "content": "forecast"}],
+        max_tokens=16000,
+        fallbacks=[{"model": "claude-opus-4-8"}],
+        betas=["server-side-fallback-2026-06-01"],
+    )
+    mock_client.messages.stream.assert_not_called()
+
+
 def test_anthropic_provider_uses_sdk_final_text_helper():
     """Provider should use Anthropic SDK final-text extraction."""
     from utils.llm.providers.anthropic import AnthropicProvider

--- a/utils/llm/metadata/models_dev_snapshot.json
+++ b/utils/llm/metadata/models_dev_snapshot.json
@@ -336,6 +336,19 @@
           "temperature": true,
           "tool_call": true
         },
+        "gemini-3.6-flash": {
+          "id": "gemini-3.6-flash",
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "name": "Gemini 3.6 Flash",
+          "reasoning": true,
+          "release_date": "2026-07-21",
+          "structured_output": true,
+          "temperature": true,
+          "tool_call": true
+        },
         "gemma-4-31b-it": {
           "id": "gemma-4-31b-it",
           "limit": {

--- a/utils/llm/metadata/models_dev_snapshot.json
+++ b/utils/llm/metadata/models_dev_snapshot.json
@@ -637,6 +637,20 @@
           "temperature": false,
           "tool_call": true
         },
+        "gpt-5.6-sol": {
+          "id": "gpt-5.6-sol",
+          "limit": {
+            "context": 1050000,
+            "input": 922000,
+            "output": 128000
+          },
+          "name": "GPT-5.6 Sol",
+          "reasoning": true,
+          "release_date": "2026-07-09",
+          "structured_output": true,
+          "temperature": false,
+          "tool_call": true
+        },
         "o3": {
           "id": "o3",
           "limit": {

--- a/utils/llm/metadata/models_dev_snapshot.json
+++ b/utils/llm/metadata/models_dev_snapshot.json
@@ -63,6 +63,18 @@
           "temperature": true,
           "tool_call": true
         },
+        "claude-fable-5": {
+          "id": "claude-fable-5",
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "name": "Claude Fable 5",
+          "reasoning": true,
+          "release_date": "2026-06-09",
+          "temperature": false,
+          "tool_call": true
+        },
         "claude-haiku-4-5-20251001": {
           "id": "claude-haiku-4-5-20251001",
           "limit": {

--- a/utils/llm/model_registry.py
+++ b/utils/llm/model_registry.py
@@ -553,6 +553,10 @@ OPENAI_MODELS: Final[list[Model]] = [
         model_key="gpt-5.5-2026-04-23",
         models_dev_reference=ModelsDevReference(provider_id="openai", model_id="gpt-5.5"),
     ),
+    openai_model(
+        model_key="gpt-5.6-sol",
+        models_dev_reference=ModelsDevReference(provider_id="openai", model_id="gpt-5.6-sol"),
+    ),
 ]
 
 # Together models: https://docs.together.ai/docs/serverless-models

--- a/utils/llm/model_registry.py
+++ b/utils/llm/model_registry.py
@@ -933,6 +933,13 @@ ANTHROPIC_MODELS: Final[list[Model]] = [
         ),
     ),
     anthropic_model(
+        model_key="claude-fable-5",
+        models_dev_reference=ModelsDevReference(
+            provider_id="anthropic",
+            model_id="claude-fable-5",
+        ),
+    ),
+    anthropic_model(
         model_key="claude-sonnet-5",
         models_dev_reference=ModelsDevReference(
             provider_id="anthropic",

--- a/utils/llm/model_registry.py
+++ b/utils/llm/model_registry.py
@@ -1080,6 +1080,10 @@ GOOGLE_MODELS: Final[list[Model]] = [
         model_key="gemini-3.5-flash",
         models_dev_reference=ModelsDevReference(provider_id="google", model_id="gemini-3.5-flash"),
     ),
+    google_model(
+        model_key="gemini-3.6-flash",
+        models_dev_reference=ModelsDevReference(provider_id="google", model_id="gemini-3.6-flash"),
+    ),
 ]
 
 

--- a/utils/llm/model_runs.py
+++ b/utils/llm/model_runs.py
@@ -833,6 +833,30 @@ OAI_MODEL_RUNS: list[ModelRun] = [
         },
     ),
     _model_run(
+        model_run_key="gpt-5.6-sol-run-variant-01",
+        slug="gpt-5.6-sol-standard-medium-web-search",
+        model_key="gpt-5.6-sol",
+        options={
+            "reasoning": {
+                "mode": "standard",
+                "effort": "medium",
+            },
+            "tools": [{"type": "web_search"}],
+        },
+    ),
+    _model_run(
+        model_run_key="gpt-5.6-sol-run-variant-02",
+        slug="gpt-5.6-sol-pro-max-web-search",
+        model_key="gpt-5.6-sol",
+        options={
+            "reasoning": {
+                "mode": "pro",
+                "effort": "max",
+            },
+            "tools": [{"type": "web_search"}],
+        },
+    ),
+    _model_run(
         model_run_key="o3-2025-04-16-run-variant-01",
         slug="o3-2025-04-16",
         model_key="o3-2025-04-16",

--- a/utils/llm/model_runs.py
+++ b/utils/llm/model_runs.py
@@ -263,6 +263,48 @@ ANTHROPIC_MODEL_RUNS: list[ModelRun] = [
         options={"max_tokens": 1024, "temperature": 0},
     ),
     _model_run(
+        model_run_key="claude-fable-5-run-variant-01",
+        slug="claude-fable-5-high-web-search-128k",
+        model_key="claude-fable-5",
+        options={
+            "max_tokens": 128000,
+            "output_config": {"effort": "high"},
+            "fallbacks": [{"model": "claude-opus-4-8"}],
+            "betas": ["server-side-fallback-2026-06-01"],
+            "tools": [
+                {
+                    "type": "web_search_20260318",
+                    "name": "web_search",
+                },
+                {
+                    "type": "web_fetch_20260318",
+                    "name": "web_fetch",
+                },
+            ],
+        },
+    ),
+    _model_run(
+        model_run_key="claude-fable-5-run-variant-02",
+        slug="claude-fable-5-max-web-search-128k",
+        model_key="claude-fable-5",
+        options={
+            "max_tokens": 128000,
+            "output_config": {"effort": "max"},
+            "fallbacks": [{"model": "claude-opus-4-8"}],
+            "betas": ["server-side-fallback-2026-06-01"],
+            "tools": [
+                {
+                    "type": "web_search_20260318",
+                    "name": "web_search",
+                },
+                {
+                    "type": "web_fetch_20260318",
+                    "name": "web_fetch",
+                },
+            ],
+        },
+    ),
+    _model_run(
         model_run_key="claude-haiku-4-5-20251001-run-variant-01",
         slug="claude-haiku-4-5-20251001-1024",
         model_key="claude-haiku-4-5-20251001",

--- a/utils/llm/model_runs.py
+++ b/utils/llm/model_runs.py
@@ -650,6 +650,24 @@ GOOGLE_MODEL_RUNS: list[ModelRun] = [
             "tools": [{"googleSearch": {}}],
         },
     ),
+    _model_run(
+        model_run_key="gemini-3.6-flash-run-variant-01",
+        slug="gemini-3.6-flash-medium-web-search",
+        model_key="gemini-3.6-flash",
+        options={
+            "thinking_config": {"thinking_level": "medium"},
+            "tools": [{"googleSearch": {}}, {"urlContext": {}}],
+        },
+    ),
+    _model_run(
+        model_run_key="gemini-3.6-flash-run-variant-02",
+        slug="gemini-3.6-flash-high-web-search",
+        model_key="gemini-3.6-flash",
+        options={
+            "thinking_config": {"thinking_level": "high"},
+            "tools": [{"googleSearch": {}}, {"urlContext": {}}],
+        },
+    ),
 ]
 
 

--- a/utils/llm/providers/anthropic.py
+++ b/utils/llm/providers/anthropic.py
@@ -12,6 +12,12 @@ from .base import BaseLLMProvider
 
 logger = logging.getLogger(__name__)
 
+_BETA_MESSAGES_OPTION_KEYS = frozenset({"betas", "fallbacks", "fallback_credit_token"})
+
+
+def _uses_beta_messages_api(options: dict[str, Any]) -> bool:
+    return bool(_BETA_MESSAGES_OPTION_KEYS & options.keys())
+
 
 class AnthropicProvider(BaseLLMProvider):
     """LLM provider that communicates with the Anthropic Messages API."""
@@ -48,7 +54,13 @@ class AnthropicProvider(BaseLLMProvider):
             ],
         }
 
-        with self._anthropic_console.messages.stream(**call_args) as stream:
+        messages = (
+            self._anthropic_console.beta.messages
+            if _uses_beta_messages_api(options)
+            else self._anthropic_console.messages
+        )
+
+        with messages.stream(**call_args) as stream:
             stream.until_done()
 
             try:


### PR DESCRIPTION
Adds registry and max model-run support for Claude Fable 5, Claude Opus 5, Gemini 3.6 Flash, and GPT-5.6-sol, including web-search and code-execution variants. It also updates the provider SDK versions, supports Anthropic’s beta Messages API for server-side fallbacks, refreshes Models.dev metadata, and preserves historical Anthropic models as manual entries.
The four new max/code-execution runs passed the ForecastBench smoke test with no request timeouts.